### PR TITLE
React Router を導入し Home/About ページを追加

### DIFF
--- a/TECH_STACK.md
+++ b/TECH_STACK.md
@@ -10,6 +10,7 @@
 | 区分 | 技術 |
 | --- | --- |
 | フレームワーク | React 19 |
+| ルーティング | React Router 7 |
 | 言語 | TypeScript 6 |
 | ビルドツール | Vite 8 |
 | スタイリング | Tailwind CSS 4 |
@@ -23,6 +24,7 @@
 
 - **React** `^19.2.6` — UI ライブラリ
 - **React DOM** `^19.2.6` — DOM レンダリング
+- **React Router** `^7.17.0` — クライアントサイドルーティング（`main.tsx` で `BrowserRouter`、`App.tsx` でルート定義）
 
 ## スタイリング
 
@@ -73,8 +75,9 @@ my-portfolio/
 ├── public/          # 静的ファイル (favicon, icons など)
 ├── src/
 │   ├── assets/      # 画像 (hero.png, logo など)
-│   ├── App.tsx      # ルートコンポーネント
-│   ├── main.tsx     # エントリーポイント
+│   ├── pages/       # ページコンポーネント (Home, About など)
+│   ├── App.tsx      # ルート定義 (React Router)
+│   ├── main.tsx     # エントリーポイント (BrowserRouter)
 │   ├── App.css
 │   └── index.css
 ├── index.html

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react-dom": "^19.2.6",
+    "react-router": "^7.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       react-dom:
         specifier: ^19.2.6
         version: 19.2.7(react@19.2.7)
+      react-router:
+        specifier: ^7.17.0
+        version: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -544,6 +547,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -897,6 +904,16 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
+  react-router@7.17.0:
+    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
@@ -917,6 +934,9 @@ packages:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1513,6 +1533,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -1816,6 +1838,14 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
+  react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.7
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+
   react@19.2.7: {}
 
   rolldown@1.0.3:
@@ -1844,6 +1874,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.4: {}
+
+  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,14 @@
+import { Routes, Route } from 'react-router'
 import './App.css'
+import Home from './pages/Home'
+import About from './pages/About'
 
 function App() {
   return (
-    <h1 className="text-3xl font-bold text-slate-800">Home</h1>
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/about" element={<About />} />
+    </Routes>
   )
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,14 @@
+import { Link } from 'react-router'
+
+function About() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-slate-800">About</h1>
+      <Link to="/" className="mt-4 inline-block text-blue-600 underline">
+        Home へ
+      </Link>
+    </div>
+  )
+}
+
+export default About

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,14 @@
+import { Link } from 'react-router'
+
+function Home() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-slate-800">Home</h1>
+      <Link to="/about" className="mt-4 inline-block text-blue-600 underline">
+        About へ
+      </Link>
+    </div>
+  )
+}
+
+export default Home


### PR DESCRIPTION
## 概要
React Router 7 を導入し、`/`（Home）と `/about`（About）の2ページ構成にした。ページ間を相互リンクで行き来できる。

## 変更点
- `react-router` 7 を導入
- `main.tsx` を `BrowserRouter` でラップ
- `App.tsx` に `/` と `/about` のルートを定義
- `src/pages/Home.tsx`：About へのリンクを表示
- `src/pages/About.tsx`：Home へのリンクを表示
- TECH_STACK.md にルーティングとページ構成を追記

## 確認
- `pnpm run build` / `pnpm run lint` 成功
- `vite preview` で `/`・`/about` ともに HTTP 200（SPA 配信）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)