### PR TITLE
React Router v8 の future フラグを有効化

### DIFF
--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -5,4 +5,12 @@ export default {
   ssr: false,
   // 既知の静的ルートをすべて事前レンダリング（ブログ記事など動的ルートは関数で返す）。
   prerender: true,
+  // React Router v8 の新挙動を先取りで有効化（警告解消＋将来の移行を楽に）。
+  future: {
+    v8_middleware: true,
+    v8_splitRouteModules: true,
+    v8_viteEnvironmentApi: true,
+    v8_passThroughRequests: true,
+    v8_trailingSlashAwareDataRequests: true,
+  },
 } satisfies Config


### PR DESCRIPTION
## 概要
ビルド時に出ていた React Router の **Future Flag Warning 5件**を解消するため、`react-router.config.ts` の `future` で v8 の新挙動を先取り有効化。

## 変更点
- `future` に以下を追加:
  - `v8_middleware`
  - `v8_splitRouteModules`
  - `v8_viteEnvironmentApi`
  - `v8_passThroughRequests`
  - `v8_trailingSlashAwareDataRequests`

## 確認
- `pnpm run build`：Future Flag Warning が **0件**に。`/`・`/about` の prerender も正常
- `pnpm run typecheck` / `pnpm run lint` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)