### PR TITLE
フィーチャーベース構成に再編

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 技術構成・開発コマンドの詳細は [TECH_STACK.md](TECH_STACK.md) を参照。
 
 - 技術構成（依存パッケージ・バージョン・ツール・Node バージョン）に変更があったら、必ず [TECH_STACK.md](TECH_STACK.md) を更新すること。
+- コードはフィーチャーベース構成：ページの中身とテストは `app/features/<name>/pages/`、機能固有の部品は `app/features/<name>/components/`、`app/routes/` はルートの配線（薄いラッパー、`loader`/`meta` はここ）。詳細は [TECH_STACK.md](TECH_STACK.md)。
 
 ## Git 運用ルール
 

--- a/TECH_STACK.md
+++ b/TECH_STACK.md
@@ -83,7 +83,16 @@
 my-portfolio/
 ├── public/                 # 静的ファイル (favicon など)
 ├── app/
-│   ├── routes/             # ページ (home.tsx, about.tsx など)
+│   ├── routes/             # ルートの配線（loader/meta + page を呼ぶ薄いラッパー）
+│   │   ├── home.tsx
+│   │   └── about.tsx
+│   ├── features/           # 機能ごとにまとめる（フィーチャーベース）
+│   │   ├── home/
+│   │   │   ├── pages/      #   ページの中身 + テスト (HomePage.tsx / .test.tsx)
+│   │   │   └── components/ #   (今後) その機能固有のコンポーネント
+│   │   └── about/
+│   │       ├── pages/
+│   │       └── components/
 │   ├── routes.ts           # ルート定義
 │   ├── root.tsx            # 共通レイアウト (html/head/body)
 │   └── app.css             # Tailwind の読み込み
@@ -95,3 +104,7 @@ my-portfolio/
 ```
 
 > ビルド成果物は `build/client/`（静的ファイル）。型生成は `.react-router/`（いずれも Git 管理外）。
+>
+> パスエイリアス `~/*` → `app/*`（例: `~/features/home/pages/HomePage`）。
+>
+> **役割分担**: `routes/` はルートの配線（`loader`/`meta` はここ）、`features/<name>/pages/` はページの中身（純粋な UI）でテストを colocate。`features/<name>/components/` は今後その機能固有の部品を置く。

--- a/app/features/about/pages/AboutPage.test.tsx
+++ b/app/features/about/pages/AboutPage.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it } from 'vitest'
+import AboutPage from './AboutPage'
+
+describe('AboutPage', () => {
+  it('見出しと Home へのリンクを表示する', () => {
+    render(
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'About' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Home へ' })).toHaveAttribute(
+      'href',
+      '/',
+    )
+  })
+})

--- a/app/features/about/pages/AboutPage.tsx
+++ b/app/features/about/pages/AboutPage.tsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router'
+
+export default function AboutPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-slate-800">About</h1>
+      <Link to="/" className="mt-4 inline-block text-blue-600 underline">
+        Home へ
+      </Link>
+    </div>
+  )
+}

--- a/app/features/home/pages/HomePage.test.tsx
+++ b/app/features/home/pages/HomePage.test.tsx
@@ -1,13 +1,13 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { describe, expect, it } from 'vitest'
-import Home from './home'
+import HomePage from './HomePage'
 
-describe('Home', () => {
+describe('HomePage', () => {
   it('見出しと About へのリンクを表示する', () => {
     render(
       <MemoryRouter>
-        <Home />
+        <HomePage />
       </MemoryRouter>,
     )
 

--- a/app/features/home/pages/HomePage.tsx
+++ b/app/features/home/pages/HomePage.tsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router'
+
+export default function HomePage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-slate-800">Home</h1>
+      <Link to="/about" className="mt-4 inline-block text-blue-600 underline">
+        About へ
+      </Link>
+    </div>
+  )
+}

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -1,12 +1,5 @@
-import { Link } from 'react-router'
+import AboutPage from '~/features/about/pages/AboutPage'
 
-export default function About() {
-  return (
-    <div className="p-8">
-      <h1 className="text-3xl font-bold text-slate-800">About</h1>
-      <Link to="/" className="mt-4 inline-block text-blue-600 underline">
-        Home へ
-      </Link>
-    </div>
-  )
+export default function AboutRoute() {
+  return <AboutPage />
 }

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,12 +1,5 @@
-import { Link } from 'react-router'
+import HomePage from '~/features/home/pages/HomePage'
 
-export default function Home() {
-  return (
-    <div className="p-8">
-      <h1 className="text-3xl font-bold text-slate-800">Home</h1>
-      <Link to="/about" className="mt-4 inline-block text-blue-600 underline">
-        About へ
-      </Link>
-    </div>
-  )
+export default function HomeRoute() {
+  return <HomePage />
 }


### PR DESCRIPTION
## 概要
route ファイルに直接書いていたページの中身を、**フィーチャーベース構成**に再編。今後ページ/機能が増えても破綻しにくい構造にする。

## 変更点
- ページの中身を `app/features/<name>/pages/` に切り出し（`HomePage.tsx` / `AboutPage.tsx`）
- テストを各ページに colocate（`HomePage.test.tsx` / `AboutPage.test.tsx`）
- `app/routes/home.tsx` / `about.tsx` を page を呼ぶ薄いラッパーに（`loader`/`meta` の置き場として残す）
- 旧 `app/routes/home.test.tsx` を削除
- `app/features/<name>/components/` は今後その機能固有の部品用（今は空）
- CLAUDE.md / TECH_STACK.md に構成と役割分担を明記

## 構成
```
app/
├── routes/                     # ルートの配線（薄いラッパー）
└── features/<name>/
    ├── pages/                  # ページの中身 + テスト
    └── components/             # (今後) 機能固有の部品
```

## 確認
- `pnpm run typecheck`（`~/` エイリアス解決）/ `pnpm run test`（2 passed）/ `biome check` 成功
- `pnpm run build`：`/`・`/about` の prerender 正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)