### PR TITLE
各ページに最低限の meta を定義（+ /about プリレンダリングの regression 修正）

### DIFF
--- a/app/config/site.ts
+++ b/app/config/site.ts
@@ -1,0 +1,7 @@
+// サイト全体で使う共通設定。サイト名はここだけ変えれば全ページに反映される。
+export const SITE_NAME = "Ryo's Portfolio"
+
+// ページタイトルを「{ページ名} | {サイト名}」形式に組み立てる。
+export function pageTitle(title: string) {
+  return `${title} | ${SITE_NAME}`
+}

--- a/app/routes/about.test.ts
+++ b/app/routes/about.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import type { Route } from './+types/about'
+import { meta } from './about'
+
+describe('about route meta', () => {
+  it('title と description を返す', () => {
+    const result = meta({} as Route.MetaArgs)
+
+    expect(result).toContainEqual({ title: 'About | my-portfolio' })
+    expect(result).toContainEqual({
+      name: 'description',
+      content: 'my-portfolio の自己紹介ページ',
+    })
+  })
+})

--- a/app/routes/about.test.ts
+++ b/app/routes/about.test.ts
@@ -6,10 +6,10 @@ describe('about route meta', () => {
   it('title と description を返す', () => {
     const result = meta({} as Route.MetaArgs)
 
-    expect(result).toContainEqual({ title: 'About | my-portfolio' })
+    expect(result).toContainEqual({ title: "About | Ryo's Portfolio" })
     expect(result).toContainEqual({
       name: 'description',
-      content: 'my-portfolio の自己紹介ページ',
+      content: "Ryo's Portfolio の自己紹介ページ",
     })
   })
 })

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -1,4 +1,12 @@
 import AboutPage from '~/features/about/pages/AboutPage'
+import type { Route } from './+types/about'
+
+export function meta(_: Route.MetaArgs) {
+  return [
+    { title: 'About | my-portfolio' },
+    { name: 'description', content: 'my-portfolio の自己紹介ページ' },
+  ]
+}
 
 export default function AboutRoute() {
   return <AboutPage />

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -1,10 +1,11 @@
+import { pageTitle, SITE_NAME } from '~/config/site'
 import AboutPage from '~/features/about/pages/AboutPage'
 import type { Route } from './+types/about'
 
 export function meta(_: Route.MetaArgs) {
   return [
-    { title: 'About | my-portfolio' },
-    { name: 'description', content: 'my-portfolio の自己紹介ページ' },
+    { title: pageTitle('About') },
+    { name: 'description', content: `${SITE_NAME} の自己紹介ページ` },
   ]
 }
 

--- a/app/routes/home.test.ts
+++ b/app/routes/home.test.ts
@@ -6,10 +6,10 @@ describe('home route meta', () => {
   it('title と description を返す', () => {
     const result = meta({} as Route.MetaArgs)
 
-    expect(result).toContainEqual({ title: 'Home | my-portfolio' })
+    expect(result).toContainEqual({ title: "Home | Ryo's Portfolio" })
     expect(result).toContainEqual({
       name: 'description',
-      content: 'my-portfolio のトップページ',
+      content: "Ryo's Portfolio のトップページ",
     })
   })
 })

--- a/app/routes/home.test.ts
+++ b/app/routes/home.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import type { Route } from './+types/home'
+import { meta } from './home'
+
+describe('home route meta', () => {
+  it('title と description を返す', () => {
+    const result = meta({} as Route.MetaArgs)
+
+    expect(result).toContainEqual({ title: 'Home | my-portfolio' })
+    expect(result).toContainEqual({
+      name: 'description',
+      content: 'my-portfolio のトップページ',
+    })
+  })
+})

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,4 +1,12 @@
 import HomePage from '~/features/home/pages/HomePage'
+import type { Route } from './+types/home'
+
+export function meta(_: Route.MetaArgs) {
+  return [
+    { title: 'Home | my-portfolio' },
+    { name: 'description', content: 'my-portfolio のトップページ' },
+  ]
+}
 
 export default function HomeRoute() {
   return <HomePage />

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,10 +1,11 @@
+import { pageTitle, SITE_NAME } from '~/config/site'
 import HomePage from '~/features/home/pages/HomePage'
 import type { Route } from './+types/home'
 
 export function meta(_: Route.MetaArgs) {
   return [
-    { title: 'Home | my-portfolio' },
-    { name: 'description', content: 'my-portfolio のトップページ' },
+    { title: pageTitle('Home') },
+    { name: 'description', content: `${SITE_NAME} のトップページ` },
   ]
 }
 

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -6,11 +6,12 @@ export default {
   // 既知の静的ルートをすべて事前レンダリング（ブログ記事など動的ルートは関数で返す）。
   prerender: true,
   // React Router v8 の新挙動を先取りで有効化（警告解消＋将来の移行を楽に）。
+  // NOTE: v8_trailingSlashAwareDataRequests は有効にすると SSG で index 以外の
+  // ルート（例: /about）が空シェル化してプリレンダリングされないため、あえて無効のまま。
   future: {
     v8_middleware: true,
     v8_splitRouteModules: true,
     v8_viteEnvironmentApi: true,
     v8_passThroughRequests: true,
-    v8_trailingSlashAwareDataRequests: true,
   },
 } satisfies Config

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { reactRouter } from '@react-router/dev/vite'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite'
@@ -5,4 +6,10 @@ import { defineConfig } from 'vite'
 // https://reactrouter.com/start/framework/installation
 export default defineConfig({
   plugins: [tailwindcss(), reactRouter()],
+  resolve: {
+    alias: {
+      // tsconfig の paths "~/*" -> "app/*" に合わせる（dev/build 双方で解決）
+      '~': fileURLToPath(new URL('./app', import.meta.url)),
+    },
+  },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
@@ -5,6 +6,12 @@ import { defineConfig } from 'vitest/config'
 // React 変換のみ @vitejs/plugin-react で行う。
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      // tsconfig の paths "~/*" -> "app/*" に合わせる
+      '~': fileURLToPath(new URL('./app', import.meta.url)),
+    },
+  },
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],


### PR DESCRIPTION
## 概要
各ページ（Home / About）に最低限の `meta`（title + description）を定義。あわせて、meta 追加時に発覚した **/about が SSG で空シェル化する regression** を修正。

## 変更点
### fix（regression）
- `v8_trailingSlashAwareDataRequests` を無効化。これを有効にすると SSG で index 以外のルート（`/about`）が**本文も meta も無い空シェル**になっていた（PR #8 で混入）。他の4フラグは維持

### feat（meta）
- `app/routes/home.tsx` / `about.tsx` に `meta`（title + description）を追加（route 側＝framework mode の置き場、`Route.MetaArgs` 型を利用）
- `meta` の返り値を検証する route テストを追加（`home.test.ts` / `about.test.ts`）
- route テストが `~/` エイリアスを解決できるよう `vitest.config.ts` に alias を追加

## 確認
- `pnpm run build`：`/`・`/about` ともに本文 + `<title>` + description を含む静的 HTML を生成（警告も0件）
- `pnpm run test`：4 passed / `typecheck` / `biome check` 成功

## 補足
PR #8 では警告数しか確認しておらず /about の中身まで見ていなかったため、この regression を見逃していました。今回の meta 追加で表面化したものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)