### PR TITLE
GitHub MCP を PAT 認証に変更

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,10 @@
     },
     "github": {
       "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/"
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_PAT}"
+      }
     },
     "shadcn": {
       "type": "stdio",


### PR DESCRIPTION
## 概要
GitHub MCP の OAuth 認証が繋がらないため、**PAT（個人アクセストークン）方式**に切り替える。

## 変更点
- `.mcp.json` の github に `Authorization: Bearer ${GITHUB_PAT}` ヘッダを追加
- トークンは**直書きせず環境変数参照**（`${GITHUB_PAT}`）。リポジトリに秘密情報を含めない

## 利用手順（マージ後）
1. GitHub で PAT を発行（後述のスコープ）
2. `GITHUB_PAT` 環境変数を設定（シェルの profile 等）
3. Claude Code セッションを開き直し、`/mcp` で github が `✓ Connected` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)