### PR TITLE
GitHub MCP を削除（context7 / shadcn に整理）

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,10 +4,6 @@
       "type": "http",
       "url": "https://mcp.context7.com/mcp"
     },
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/"
-    },
     "shadcn": {
       "type": "stdio",
       "command": "npx",


### PR DESCRIPTION
## 概要
PR 作成・マージ等は `gh` CLI で既にできており、OAuth/PAT 認証の手間に見合わないため **github MCP を削除**。

## 変更点
- `.mcp.json` から github エントリを削除
- 残: **context7**（最新ドキュメント）/ **shadcn**（コンポーネント操作）— どちらも認証不要

## 補足
- 将来必要になれば再追加は容易（PAT or OAuth）

🤖 Generated with [Claude Code](https://claude.com/claude-code)