### PR TITLE
CI（GitHub Actions）と Dependabot を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # npm / pnpm の依存パッケージ
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # minor / patch はまとめて 1 つの PR に（major は個別 PR で慎重にレビュー）
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions のバージョン
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # package.json の packageManager (pnpm) を読んで pnpm を用意
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Biome（lint + format + import 整理）を CI モードでチェック
+      - run: pnpm exec biome ci .
+
+      - run: pnpm run typecheck
+
+      - run: pnpm run test
+
+      - run: pnpm run build

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -75,6 +75,11 @@
 
 - **Biome** `^2.4.16` — Lint と Format を一手に担うツール（設定は `biome.json`）。`.gitignore` を尊重して `build` / `.react-router` を除外
 
+## CI / 依存管理
+
+- **GitHub Actions**（`.github/workflows/ci.yml`）— PR/`main` push ごとに `biome ci` / `typecheck` / `test` / `build` を実行
+- **Dependabot**（`.github/dependabot.yml`）— 依存パッケージと GitHub Actions を**週1**で更新。minor/patch はまとめて1 PR、major は個別 PR
+
 ---
 
 ## スクリプト

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
-onlyBuiltDependencies:
-  - esbuild
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## 概要
依存の定期更新を安全に回すため、**CI** と **Dependabot** を追加。

## CI（`.github/workflows/ci.yml`）
- トリガー：`main` への PR / push
- 内容：`pnpm install --frozen-lockfile` → `biome ci` → `typecheck` → `test` → `build`
- pnpm は `packageManager` を読む `pnpm/action-setup`、Node は `.node-version` を使用

## Dependabot（`.github/dependabot.yml`）
- npm/pnpm と GitHub Actions を**週1**で更新
- minor/patch はまとめて 1 PR、major は個別 PR（壊れやすい更新を分離）
- 更新 PR は上記 CI で自動検証される

## 確認
- `biome ci .` ローカル通過
- ※ ワークフロー自体はこの PR の CI 実行で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)