### PR TITLE
カラーモード切替（Light/Dark/System）を追加

### DIFF
--- a/app/components/layout/Header/Header.tsx
+++ b/app/components/layout/Header/Header.tsx
@@ -2,6 +2,7 @@ import { Link, NavLink } from 'react-router'
 import Avatar from '~/components/base/Avatar'
 import Button from '~/components/base/Button'
 import MobileNav from '~/components/layout/MobileNav'
+import ThemeToggle from '~/components/layout/ThemeToggle'
 
 /** ヘッダーのナビ項目。PC のインラインナビとモバイルの MobileNav の両方で使う。 */
 const navItems = [
@@ -17,17 +18,21 @@ export default function Header() {
       <Link to="/" aria-label="Home">
         <Avatar src="/avatar.jpg" alt="Ryo" fallback="R" className="size-12" />
       </Link>
-      {/* PC: インラインナビ */}
-      <nav className="hidden items-center gap-1 md:flex">
-        {navItems.map((item) => (
-          <Button key={item.to} variant="ghost" asChild>
-            <NavLink to={item.to}>{item.label}</NavLink>
-          </Button>
-        ))}
-      </nav>
-      {/* モバイル: ハンバーガーメニュー */}
-      <div className="md:hidden">
-        <MobileNav items={navItems} />
+      <div className="flex items-center gap-1">
+        {/* PC: インラインナビ */}
+        <nav className="hidden items-center gap-1 md:flex">
+          {navItems.map((item) => (
+            <Button key={item.to} variant="ghost" asChild>
+              <NavLink to={item.to}>{item.label}</NavLink>
+            </Button>
+          ))}
+        </nav>
+        {/* モバイル: ハンバーガーメニュー */}
+        <div className="md:hidden">
+          <MobileNav items={navItems} />
+        </div>
+        {/* 一番右: カラーモード切替 */}
+        <ThemeToggle />
       </div>
     </header>
   )

--- a/app/components/layout/ThemeToggle/ThemeToggle.stories.tsx
+++ b/app/components/layout/ThemeToggle/ThemeToggle.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import ThemeToggle from './ThemeToggle'
+
+const meta = {
+  title: 'Components/Layout/ThemeToggle',
+  component: ThemeToggle,
+} satisfies Meta<typeof ThemeToggle>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/app/components/layout/ThemeToggle/ThemeToggle.test.tsx
+++ b/app/components/layout/ThemeToggle/ThemeToggle.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+import ThemeToggle from './ThemeToggle'
+
+afterEach(() => {
+  localStorage.clear()
+  document.documentElement.className = ''
+})
+
+describe('ThemeToggle', () => {
+  it('Dark を選ぶと dark クラスと localStorage に反映される', async () => {
+    const user = userEvent.setup()
+    render(<ThemeToggle />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'カラーモードを切り替える' }),
+    )
+    await user.click(await screen.findByRole('menuitemradio', { name: 'Dark' }))
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(localStorage.getItem('theme')).toBe('dark')
+  })
+})

--- a/app/components/layout/ThemeToggle/ThemeToggle.tsx
+++ b/app/components/layout/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,40 @@
+import { Moon, Sun } from 'lucide-react'
+import Button from '~/components/base/Button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '~/components/ui/dropdown-menu'
+import { type Theme, useTheme } from './useTheme'
+
+/** カラーモード（Light / Dark / System）を切り替えるプルダウン。選択は localStorage に保持。 */
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="カラーモードを切り替える"
+        >
+          <Sun className="dark:hidden" />
+          <Moon className="hidden dark:block" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={theme}
+          onValueChange={(value) => setTheme(value as Theme)}
+        >
+          <DropdownMenuRadioItem value="light">Light</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="dark">Dark</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="system">System</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/app/components/layout/ThemeToggle/index.ts
+++ b/app/components/layout/ThemeToggle/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ThemeToggle'

--- a/app/components/layout/ThemeToggle/useTheme.ts
+++ b/app/components/layout/ThemeToggle/useTheme.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark' | 'system'
+
+/** localStorage に保存するキー。inline script（root.tsx）と一致させること。 */
+export const THEME_STORAGE_KEY = 'theme'
+
+/** 指定テーマを実際の見た目（html の dark クラス）に反映する。 */
+export function applyTheme(theme: Theme) {
+  const isDark =
+    theme === 'dark' ||
+    (theme === 'system' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches)
+  document.documentElement.classList.toggle('dark', isDark)
+}
+
+/** カラーモード（light/dark/system）の取得・切替を行うフック。値は localStorage に保持。 */
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>('system')
+
+  // 初回マウントで保存値を読む（初期描画は inline script が既に dark クラスを当てている）
+  useEffect(() => {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY) as Theme | null
+    if (stored) setThemeState(stored)
+  }, [])
+
+  // system 選択時は OS のテーマ変更に追従する
+  useEffect(() => {
+    if (theme !== 'system') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = () => applyTheme('system')
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [theme])
+
+  const setTheme = (next: Theme) => {
+    localStorage.setItem(THEME_STORAGE_KEY, next)
+    applyTheme(next)
+    setThemeState(next)
+  }
+
+  return { theme, setTheme }
+}

--- a/app/components/ui/dropdown-menu.tsx
+++ b/app/components/ui/dropdown-menu.tsx
@@ -1,0 +1,267 @@
+import * as React from "react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "~/lib/utils"
+import { CheckIcon, ChevronRightIcon } from "lucide-react"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        align={align}
+        className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,13 +1,18 @@
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from 'react-router'
 import './app.css'
 
+// 初回描画前に保存テーマ（無ければ system）を html の dark クラスに反映し、チラつきを防ぐ
+const themeInitScript = `(function(){try{var t=localStorage.getItem('theme')||'system';var d=t==='dark'||(t==='system'&&matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.classList.toggle('dark',d);}catch(e){}})();`
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ja">
+    <html lang="ja" suppressHydrationWarning>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: テーマ適用の inline script */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         <Meta />
         <Links />
       </head>

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -125,7 +125,8 @@ my-portfolio/
 │   │   │   └── Avatar/     #     ui/avatar のラッパー（src/alt/fallback/className）
 │   │   ├── layout/         #   全ページ横断のレイアウトのガワ
 │   │   │   ├── Header/     #     サイト共通ヘッダー（layout ルートで表示）
-│   │   │   └── MobileNav/  #     モバイル用ハンバーガーメニュー（Sheet）
+│   │   │   ├── MobileNav/  #     モバイル用ハンバーガーメニュー（Sheet）
+│   │   │   └── ThemeToggle/ #    カラーモード切替（Light/Dark/System・localStorage 保持）
 │   │   └── ui/             #   shadcn/ui（vendored・編集しない・Biome 対象外）
 │   ├── config/             # サイト共通設定 (site.ts: SITE_NAME など)
 │   ├── lib/                # 汎用ユーティリティ (utils.ts: cn など)

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,9 +1,24 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
-import { afterEach } from 'vitest'
+import { afterEach, vi } from 'vitest'
 
 // globals: false のため Testing Library の自動クリーンアップが効かない。
 // テストごとにレンダリング結果を破棄して分離する。
 afterEach(() => {
   cleanup()
+})
+
+// jsdom は matchMedia を実装していないためモックする（常に light を返す）。
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }),
 })


### PR DESCRIPTION
## 概要
ヘッダー右端に**カラーモード切替プルダウン**を追加。**Light / Dark / System の3択**で、選択は**ブラウザに保持（localStorage）**。

## 仕組み
- **ThemeToggle**（`app/components/layout/ThemeToggle/`）：shadcn dropdown-menu の RadioGroup で3択。トリガーは現在モードに応じて Sun/Moon 表示
- **useTheme**：`html` の `dark` クラスを付け外し、`system` 選択時は OS 設定に追従、選択を localStorage に保存
- **チラつき防止**：SSG（prerender）は初期ライトのため、`root.tsx` の `<head>` に inline script を入れ、**初回描画前に保存テーマを適用**（+ `suppressHydrationWarning`）
- テーマ変数は既存の shadcn `.dark`（`app/app.css`）を利用

## 規約準拠
- shadcn は `ui/` のまま、利用はラッパー（ThemeToggle）経由。test / story / バレル付き、story title `Components/Layout/ThemeToggle`

## 確認
- `typecheck` / `test`（12 passed・Dark 選択で dark クラス＋localStorage 反映を検証）/ `biome` / `build`（4ルート prerender・inline script 出力）/ `build-storybook` すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)