### PR TITLE
Works（作品集）の仮ページを追加

### DIFF
--- a/app/components/layout/Header/Header.tsx
+++ b/app/components/layout/Header/Header.tsx
@@ -7,6 +7,7 @@ import ThemeToggle from '~/components/layout/ThemeToggle'
 /** ヘッダーのナビ項目。PC のインラインナビとモバイルの MobileNav の両方で使う。 */
 const navItems = [
   { label: 'About', to: '/about' },
+  { label: 'Works', to: '/works' },
   { label: 'Tools', to: '/tools' },
   { label: 'Blog', to: '/blog' },
 ]

--- a/app/features/works/pages/WorksPage.test.tsx
+++ b/app/features/works/pages/WorksPage.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import WorksPage from './WorksPage'
+
+describe('WorksPage', () => {
+  it('見出しを表示する', () => {
+    render(<WorksPage />)
+
+    expect(screen.getByRole('heading', { name: 'Works' })).toBeInTheDocument()
+  })
+})

--- a/app/features/works/pages/WorksPage.tsx
+++ b/app/features/works/pages/WorksPage.tsx
@@ -1,0 +1,7 @@
+export default function WorksPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold text-slate-800">Works</h1>
+    </div>
+  )
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -9,6 +9,7 @@ export default [
   layout('routes/layout.tsx', [
     index('routes/home/home.tsx'),
     route('about', 'routes/about/about.tsx'),
+    route('works', 'routes/works/works.tsx'),
     route('tools', 'routes/tools/tools.tsx'),
     route('blog', 'routes/blog/blog.tsx'),
   ]),

--- a/app/routes/works/works.tsx
+++ b/app/routes/works/works.tsx
@@ -1,0 +1,14 @@
+import { SITE_NAME, pageTitle } from '~/config/site'
+import WorksPage from '~/features/works/pages/WorksPage'
+import type { Route } from './+types/works'
+
+export function meta(_: Route.MetaArgs) {
+  return [
+    { title: pageTitle('Works') },
+    { name: 'description', content: `${SITE_NAME} の作品集` },
+  ]
+}
+
+export default function WorksRoute() {
+  return <WorksPage />
+}

--- a/app/routes/works/works.tsx
+++ b/app/routes/works/works.tsx
@@ -1,4 +1,4 @@
-import { SITE_NAME, pageTitle } from '~/config/site'
+import { pageTitle, SITE_NAME } from '~/config/site'
 import WorksPage from '~/features/works/pages/WorksPage'
 import type { Route } from './+types/works'
 

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -117,6 +117,7 @@ my-portfolio/
 │   │   │   ├── pages/      #   ページの中身 + テスト (HomePage.tsx / .test.tsx)
 │   │   │   └── components/ #   (今後) その機能固有のコンポーネント
 │   │   ├── about/
+│   │   ├── works/          #   (仮ページ) 作品集
 │   │   ├── tools/          #   (仮ページ) 便利ツール集
 │   │   └── blog/           #   (仮ページ) ブログ
 │   ├── components/          # アプリ共通のコンポーネント


### PR DESCRIPTION
## 概要
作品集ページ `/works` を追加（今回は**見出しのみの仮ページ**）。中身（カード一覧など）は今後。

## 変更点
- `app/features/works/pages/WorksPage.tsx`（見出し "Works"）+ test
- `app/routes/works/works.tsx`（薄いラッパー + meta）/ `routes.ts` に登録
- ナビに **Works** を追加（About と Tools の間。`navItems` 共有なので PC/モバイル両方に反映）
- TECH_STACK の構成図を更新

## 確認
- `typecheck` / `test`（13 passed）/ `biome` / `build`（`/works` prerender、ナビ順 About→Works→Tools）すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)