### PR TITLE
README を実態に合わせて刷新（ESLint 記述を削除）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 技術構成・開発コマンドの詳細は [TECH_STACK.md](docs/TECH_STACK.md) を参照。
 
 - 技術構成（依存パッケージ・バージョン・ツール・Node バージョン）に変更があったら、必ず [TECH_STACK.md](docs/TECH_STACK.md) を更新すること。
+- セットアップ手順・開発コマンド・必要要件・概要など、[README.md](README.md) に書いてある内容に関わる変更があったら、README も更新すること。
 - コード構成・コンポーネント作成ルール（フィーチャーベース構成、ディレクトリの使い分け、shadcn の vendored 方針、コメント規約など）は [docs/COMPONENTS.md](docs/COMPONENTS.md) を参照。
 
 ## Git 運用ルール

--- a/README.md
+++ b/README.md
@@ -1,73 +1,32 @@
-# React + TypeScript + Vite
+# my-portfolio
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Ryo's Portfolio サイト。Vite + React Router 7（framework mode・SSG）+ TypeScript で構築。
 
-Currently, two official plugins are available:
+- 技術構成の詳細：[docs/TECH_STACK.md](docs/TECH_STACK.md)
+- コード構成・コンポーネント作成ルール：[docs/COMPONENTS.md](docs/COMPONENTS.md)
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+## 必要要件
 
-## React Compiler
+- Node.js（バージョンは [.node-version](.node-version) で固定）
+- pnpm（corepack 経由。バージョンは `package.json` の `packageManager` で固定）
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+## セットアップ
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+pnpm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## 開発コマンド
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+| コマンド | 内容 |
+| --- | --- |
+| `pnpm dev` | 開発サーバー起動 |
+| `pnpm build` | 本番ビルド（全ルートを SSG で prerender） |
+| `pnpm typecheck` | 型チェック |
+| `pnpm test` | テスト（Vitest） |
+| `pnpm lint` / `pnpm format` / `pnpm check` | Biome（Lint / 整形 / 一括チェック&修正） |
+| `pnpm storybook` | Storybook（コンポーネントカタログ）起動 |
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+## ツール
+
+Lint / Format は **Biome** に一本化（ESLint・Prettier は不使用）。設定は [biome.json](biome.json)。


### PR DESCRIPTION
## 概要
README が Vite テンプレートの初期状態のままで、**ESLint 設定の説明**や削除済みファイル（`tsconfig.app.json` 等）への言及が残っていた。プロジェクト実態に合わせて書き換え。

## 変更点
- タイトル/説明を my-portfolio 用に
- ESLint 拡張の説明セクションを削除（Lint/Format は Biome 一本化を明記）
- セットアップ・開発コマンド（pnpm / Biome / Vitest / Storybook）を記載
- docs/TECH_STACK.md・docs/COMPONENTS.md へのリンク

## 確認
- リポジトリ内の eslint/prettier 言及は README 以外に残っていないことを確認
- `biome ci` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)