### PR TITLE
VSCode 設定（保存時フォーマット・推奨拡張）を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "biomejs.biome",
+    "bradlc.vscode-tailwindcss",
+    "vitest.explorer"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.biome": "explicit",
+    "source.organizeImports.biome": "explicit"
+  },
+  "[javascript]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[javascriptreact]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[typescript]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[typescriptreact]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[json]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[jsonc]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[css]": { "editor.defaultFormatter": "biomejs.biome" }
+}

--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ pnpm install
 ## ツール
 
 Lint / Format は **Biome** に一本化（ESLint・Prettier は不使用）。設定は [biome.json](biome.json)。
+
+## エディタ（VSCode）
+
+`.vscode/` に設定を同梱：
+
+- 保存時に Biome で自動フォーマット＋import 整理（`.vscode/settings.json`）
+- 推奨拡張機能（`.vscode/extensions.json`）：Biome / Tailwind CSS IntelliSense / Vitest。VSCode で開くとインストールを促されます。


### PR DESCRIPTION
## 概要
VSCode の共有設定を追加。保存時に Biome で自動整形、推奨拡張機能を提示する。

## 変更点
- **`.vscode/settings.json`**：保存時フォーマット（`editor.formatOnSave`）＋ Biome の `source.fixAll` / `source.organizeImports`。対象言語（js/ts/jsx/tsx/json/jsonc/css）の defaultFormatter を Biome に
- **`.vscode/extensions.json`**：推奨拡張機能
  - `biomejs.biome`（Lint/Format）
  - `bradlc.vscode-tailwindcss`（Tailwind IntelliSense）
  - `vitest.explorer`（テスト）
- **`.gitignore`**：`settings.json` を共有対象に（除外解除）
- **README**：エディタ設定の案内を追記

## 確認
- `.vscode` の2ファイルが Git 追跡対象、`biome ci` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)