### PR TITLE
Node を最新 Active LTS へ自動更新するワークフロー

### DIFF
--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -1,0 +1,68 @@
+name: Update Node version
+
+# 現行 LTS 系（.node-version の major）の最新パッチに .node-version を更新する PR を定期作成する。
+on:
+  schedule:
+    - cron: "0 0 * * 1" # 毎週月曜 00:00 UTC
+  workflow_dispatch: # 手動実行も可
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 現行 LTS 系の最新パッチを取得
+        id: node
+        run: |
+          current="$(tr -d 'v\n' < .node-version)"
+          major="${current%%.*}"
+          latest="$(curl -fsSL https://nodejs.org/dist/index.json \
+            | jq -r --arg m "v${major}." '[.[] | select(.version | startswith($m))][0].version')"
+          echo "current=v${current}" >> "$GITHUB_OUTPUT"
+          echo "latest=${latest}" >> "$GITHUB_OUTPUT"
+          if [ -n "${latest}" ] && [ "${latest}" != "v${current}" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: .node-version を更新
+        if: steps.node.outputs.changed == 'true'
+        run: echo "${{ steps.node.outputs.latest }}" > .node-version
+
+      # 新しい Node で検証してから PR を出す（壊れる更新は PR にしない）
+      - uses: pnpm/action-setup@v6
+        if: steps.node.outputs.changed == 'true'
+      - uses: actions/setup-node@v6
+        if: steps.node.outputs.changed == 'true'
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - if: steps.node.outputs.changed == 'true'
+        run: pnpm install --frozen-lockfile
+      - if: steps.node.outputs.changed == 'true'
+        run: pnpm exec biome ci .
+      - if: steps.node.outputs.changed == 'true'
+        run: pnpm run typecheck
+      - if: steps.node.outputs.changed == 'true'
+        run: pnpm run test
+      - if: steps.node.outputs.changed == 'true'
+        run: pnpm run build
+
+      - name: PR 作成
+        if: steps.node.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/update-node-version
+          base: main
+          title: "chore: Node を ${{ steps.node.outputs.latest }} に更新"
+          commit-message: "chore: .node-version を ${{ steps.node.outputs.latest }} に更新"
+          body: |
+            現行 LTS 系の最新パッチに `.node-version` を更新します。
+
+            - ${{ steps.node.outputs.current }} → ${{ steps.node.outputs.latest }}
+
+            このワークフロー内で install / biome / typecheck / test / build を検証済み。

--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -1,6 +1,6 @@
 name: Update Node version
 
-# 現行 LTS 系（.node-version の major）の最新パッチに .node-version を更新する PR を定期作成する。
+# 最新の Active LTS（メジャー乗り換えも含む）に .node-version を更新する PR を定期作成する。
 on:
   schedule:
     - cron: "0 0 * * 1" # 毎週月曜 00:00 UTC
@@ -16,16 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: 現行 LTS 系の最新パッチを取得
+      - name: 最新の Active LTS を取得
         id: node
         run: |
-          current="$(tr -d 'v\n' < .node-version)"
-          major="${current%%.*}"
+          current="v$(tr -d 'v\n' < .node-version)"
+          # index.json は新しい順。lts != false（LTS）の先頭 = 最新 Active LTS の最新パッチ
           latest="$(curl -fsSL https://nodejs.org/dist/index.json \
-            | jq -r --arg m "v${major}." '[.[] | select(.version | startswith($m))][0].version')"
-          echo "current=v${current}" >> "$GITHUB_OUTPUT"
+            | jq -r '[.[] | select(.lts != false)][0].version')"
+          echo "current=${current}" >> "$GITHUB_OUTPUT"
           echo "latest=${latest}" >> "$GITHUB_OUTPUT"
-          if [ -n "${latest}" ] && [ "${latest}" != "v${current}" ]; then
+          if [ -n "${latest}" ] && [ "${latest}" != "${current}" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -61,8 +61,9 @@ jobs:
           title: "chore: Node を ${{ steps.node.outputs.latest }} に更新"
           commit-message: "chore: .node-version を ${{ steps.node.outputs.latest }} に更新"
           body: |
-            現行 LTS 系の最新パッチに `.node-version` を更新します。
+            最新の Active LTS に `.node-version` を更新します（メジャー乗り換えを含む）。
 
             - ${{ steps.node.outputs.current }} → ${{ steps.node.outputs.latest }}
 
             このワークフロー内で install / biome / typecheck / test / build を検証済み。
+            メジャー更新の場合は破壊的変更がないか中身も確認してからマージしてください。

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "biomejs.biome",
+    "bradlc.vscode-tailwindcss",
+    "vitest.explorer"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.biome": "explicit",
+    "source.organizeImports.biome": "explicit"
+  },
+  "[javascript]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[javascriptreact]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[typescript]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[typescriptreact]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[json]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[jsonc]": { "editor.defaultFormatter": "biomejs.biome" },
+  "[css]": { "editor.defaultFormatter": "biomejs.biome" }
+}

--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ pnpm install
 ## ツール
 
 Lint / Format は **Biome** に一本化（ESLint・Prettier は不使用）。設定は [biome.json](biome.json)。
+
+## エディタ（VSCode）
+
+`.vscode/` に設定を同梱：
+
+- 保存時に Biome で自動フォーマット＋import 整理（`.vscode/settings.json`）
+- 推奨拡張機能（`.vscode/extensions.json`）：Biome / Tailwind CSS IntelliSense / Vitest。VSCode で開くとインストールを促されます。

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -79,6 +79,7 @@
 
 - **GitHub Actions**（`.github/workflows/ci.yml`）— PR/`main` push ごとに `biome ci` / `typecheck` / `test` / `build` を実行
 - **Dependabot**（`.github/dependabot.yml`）— 依存パッケージと GitHub Actions を**週1**で更新。minor/patch はまとめて1 PR、major は個別 PR
+- **Node 自動更新**（`.github/workflows/update-node.yml`）— 現行 LTS 系（`.node-version` の major）の最新パッチに更新する PR を**週1**で作成（Dependabot は `.node-version` 非対応のため自前。ワークフロー内で検証してから PR）
 
 ---
 

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -79,7 +79,7 @@
 
 - **GitHub Actions**（`.github/workflows/ci.yml`）— PR/`main` push ごとに `biome ci` / `typecheck` / `test` / `build` を実行
 - **Dependabot**（`.github/dependabot.yml`）— 依存パッケージと GitHub Actions を**週1**で更新。minor/patch はまとめて1 PR、major は個別 PR
-- **Node 自動更新**（`.github/workflows/update-node.yml`）— 現行 LTS 系（`.node-version` の major）の最新パッチに更新する PR を**週1**で作成（Dependabot は `.node-version` 非対応のため自前。ワークフロー内で検証してから PR）
+- **Node 自動更新**（`.github/workflows/update-node.yml`）— **最新の Active LTS**（メジャー乗り換え含む）に `.node-version` を更新する PR を**週1**で作成（Dependabot は `.node-version` 非対応のため自前。ワークフロー内で検証してから PR）
 
 ---
 


### PR DESCRIPTION
## 概要
Dependabot は `.node-version` を更新できないため、**自前の定期ワークフロー**で **最新の Active LTS**（メジャー乗り換え含む）に追従する。

## 仕組み（`.github/workflows/update-node.yml`）
- **週1（月曜）** + 手動（`workflow_dispatch`）で起動
- nodejs.org の index.json から **lts != false の先頭**（= 最新 Active LTS の最新パッチ）を取得
- 現状と違えば `.node-version` を更新し、**新しい Node で install / biome / typecheck / test / build を検証** → 通れば PR 作成（壊れる更新は PR にしない）
- 例: 24.x のパッチも、26 が LTS 化したら v26 への乗り換えも対象（メジャー更新時は中身も確認してマージ推奨）

## 補足
- 奇数メジャー（25 等）は Node の仕様上 LTS にならないため対象外。次の LTS は 26。
- 自動 PR は `GITHUB_TOKEN` 作成で通常 CI は自動起動しないが、ワークフロー内で同等の検証済み。

## 確認
- ロジックをローカル検証：最新 Active LTS = `v24.18.0`（現状 v24.16.0 → これに更新される）
- `biome ci` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)