### PR TITLE
ヘッダーにサイト名（Ryo's Portfolio）を表示

### DIFF
--- a/app/components/layout/Header/Header.test.tsx
+++ b/app/components/layout/Header/Header.test.tsx
@@ -1,23 +1,28 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { describe, expect, it } from 'vitest'
+import { SITE_NAME } from '~/config/site'
 import Header from './Header'
 
 describe('Header', () => {
-  it('Home へのアバターリンクと About / Tools / Blog のナビを表示する', () => {
+  it('サイト名のホームリンクと About / Works / Tools / Blog のナビを表示する', () => {
     render(
       <MemoryRouter>
         <Header />
       </MemoryRouter>,
     )
 
-    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
-      'href',
-      '/',
-    )
+    // jsdom は画像を読み込まず Avatar がフォールバックを出すため、サイト名を含むかで判定
+    expect(
+      screen.getByRole('link', { name: new RegExp(SITE_NAME) }),
+    ).toHaveAttribute('href', '/')
     expect(screen.getByRole('link', { name: 'About' })).toHaveAttribute(
       'href',
       '/about',
+    )
+    expect(screen.getByRole('link', { name: 'Works' })).toHaveAttribute(
+      'href',
+      '/works',
     )
     expect(screen.getByRole('link', { name: 'Tools' })).toHaveAttribute(
       'href',

--- a/app/components/layout/Header/Header.tsx
+++ b/app/components/layout/Header/Header.tsx
@@ -3,6 +3,7 @@ import Avatar from '~/components/base/Avatar'
 import Button from '~/components/base/Button'
 import MobileNav from '~/components/layout/MobileNav'
 import ThemeToggle from '~/components/layout/ThemeToggle'
+import { SITE_NAME } from '~/config/site'
 
 /** ヘッダーのナビ項目。PC のインラインナビとモバイルの MobileNav の両方で使う。 */
 const navItems = [
@@ -16,8 +17,10 @@ const navItems = [
 export default function Header() {
   return (
     <header className="sticky top-0 z-50 flex items-center justify-between border-b bg-background px-6 py-4">
-      <Link to="/" aria-label="Home">
-        <Avatar src="/avatar.jpg" alt="Ryo" fallback="R" className="size-12" />
+      <Link to="/" className="flex items-center gap-4">
+        {/* リンク名は隣の SITE_NAME になるため、画像は装飾扱い（alt=""） */}
+        <Avatar src="/avatar.jpg" alt="" fallback="R" className="size-12" />
+        <span className="font-semibold text-xl">{SITE_NAME}</span>
       </Link>
       <div className="flex items-center gap-1">
         {/* PC: インラインナビ */}


### PR DESCRIPTION
## 概要
ヘッダー左、アバターの横に **`Ryo's Portfolio`**（`SITE_NAME` 定数）をテキスト表示。ブランド表示として Home リンク内に置く。

## 変更点
- アバター横に `SITE_NAME` を `font-semibold text-xl`、`gap-4` で配置（PC/モバイル両方表示）
- **heading 要素にはしない**（各ページの主見出し h1 を1つに保つため、ただのリンク内テキスト）
- **a11y**：可視テキストとアクセシブル名を一致させるため、リンクの `aria-label="Home"` を外し、アバター画像は装飾扱い（`alt=""`）に。リンク名＝"Ryo's Portfolio"
- Header テスト更新（ホームリンク名の変更・Works リンクの確認を追加）

## 確認
- `biome ci` / `typecheck` / `test`（13 passed）/ `build`（サイト名出力を確認）/ `build-storybook` すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)