### PR TITLE
ナビ項目を config/nav.ts に集約（Storybook の足し忘れ防止）

### DIFF
--- a/app/components/layout/Header/Header.tsx
+++ b/app/components/layout/Header/Header.tsx
@@ -3,15 +3,8 @@ import Avatar from '~/components/base/Avatar'
 import Button from '~/components/base/Button'
 import MobileNav from '~/components/layout/MobileNav'
 import ThemeToggle from '~/components/layout/ThemeToggle'
+import { NAV_ITEMS } from '~/config/nav'
 import { SITE_NAME } from '~/config/site'
-
-/** ヘッダーのナビ項目。PC のインラインナビとモバイルの MobileNav の両方で使う。 */
-const navItems = [
-  { label: 'About', to: '/about' },
-  { label: 'Works', to: '/works' },
-  { label: 'Tools', to: '/tools' },
-  { label: 'Blog', to: '/blog' },
-]
 
 /** 全ページ共通のヘッダー（左にアバター→Home、右に各ページへのナビ）。 */
 export default function Header() {
@@ -25,7 +18,7 @@ export default function Header() {
       <div className="flex items-center gap-1">
         {/* PC: インラインナビ */}
         <nav className="hidden items-center gap-1 md:flex">
-          {navItems.map((item) => (
+          {NAV_ITEMS.map((item) => (
             <Button key={item.to} variant="ghost" asChild>
               <NavLink to={item.to}>{item.label}</NavLink>
             </Button>
@@ -33,7 +26,7 @@ export default function Header() {
         </nav>
         {/* モバイル: ハンバーガーメニュー */}
         <div className="md:hidden">
-          <MobileNav items={navItems} />
+          <MobileNav items={NAV_ITEMS} />
         </div>
         {/* 一番右: カラーモード切替 */}
         <ThemeToggle />

--- a/app/components/layout/MobileNav/MobileNav.stories.tsx
+++ b/app/components/layout/MobileNav/MobileNav.stories.tsx
@@ -1,17 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { MemoryRouter } from 'react-router'
+import { NAV_ITEMS } from '~/config/nav'
 import MobileNav from './MobileNav'
 
 const meta = {
   title: 'Components/Layout/MobileNav',
   component: MobileNav,
-  args: {
-    items: [
-      { label: 'About', to: '/about' },
-      { label: 'Tools', to: '/tools' },
-      { label: 'Blog', to: '/blog' },
-    ],
-  },
+  // 実際のヘッダーと同じ NAV_ITEMS を使う（項目を増やせば story にも自動反映）
+  args: { items: NAV_ITEMS },
   decorators: [
     // NavLink を使うのでルーターコンテキストを与える
     (Story) => (

--- a/app/config/nav.ts
+++ b/app/config/nav.ts
@@ -1,0 +1,18 @@
+export type NavItem = {
+  /** リンクの表示ラベル */
+  label: string
+  /** 遷移先パス */
+  to: string
+}
+
+/**
+ * ヘッダーのナビゲーション項目。ここに追加すれば、
+ * Header（PC のインラインナビ / モバイルの MobileNav）と
+ * MobileNav の Storybook の両方に自動反映される。
+ */
+export const NAV_ITEMS: NavItem[] = [
+  { label: 'About', to: '/about' },
+  { label: 'Works', to: '/works' },
+  { label: 'Tools', to: '/tools' },
+  { label: 'Blog', to: '/blog' },
+]

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -11,7 +11,12 @@
   - `layout/`（`Header/` など）— 全ページ横断のレイアウトのガワ
   - `ui/` — shadcn/ui（後述の vendored 方針）
 - `app/routes/` — ルートの配線（薄いラッパー。`loader`/`meta` はここ）
-- `app/config/` — サイト共通設定（`site.ts`）/ `app/lib/` — 汎用ユーティリティ（`utils.ts`）
+- `app/config/` — サイト共通設定（`site.ts`: サイト名など / `nav.ts`: ナビ項目）/ `app/lib/` — 汎用ユーティリティ（`utils.ts`）
+
+## ナビゲーション項目
+
+- ヘッダーのメニューは `app/config/nav.ts` の **`NAV_ITEMS` に集約**する（単一の出所）。
+- Header（PC ナビ / モバイルの MobileNav）も MobileNav の **Storybook** も同じ `NAV_ITEMS` を参照するので、**ここに1項目足せば全部に反映される**（Storybook への追加漏れも起きない）。
 
 ## コンポーネントのファイル構成
 


### PR DESCRIPTION
## 概要
`MobileNav` の Storybook に Works が出ていなかった原因は、**story が独自にベタ書きした `items` に Works が無かった**ため。ナビ項目を単一の出所に集約して再発を防ぐ。

## 変更点
- `app/config/nav.ts` を新設し **`NAV_ITEMS`** を定義（About / Works / Tools / Blog）
- Header（PC ナビ / モバイル MobileNav）が `NAV_ITEMS` を参照（ローカルのベタ書きを削除）
- **MobileNav の Storybook も `NAV_ITEMS` を参照** → 項目を足せば story にも自動反映
- docs/COMPONENTS.md に「ナビ項目は `config/nav.ts` に集約」の方針を明記

## 効果
今後メニューを増やすときは `NAV_ITEMS` に1行足すだけで、**PC ナビ・モバイル・Storybook すべてに反映**される（足し忘れ防止）。

## 確認
- `biome ci` / `typecheck` / `test`（13 passed）/ `build` / `build-storybook` 成功
- Storybook の MobileNav に Works が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)