### PR TITLE
Heading コンポーネントを追加し各ページの見出しに適用

### DIFF
--- a/app/components/base/Heading/Heading.stories.tsx
+++ b/app/components/base/Heading/Heading.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import Heading from './Heading'
+
+const meta = {
+  title: 'Components/Base/Heading',
+  component: Heading,
+  args: { children: '見出しテキスト', level: 1 },
+} satisfies Meta<typeof Heading>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const H1: Story = { args: { level: 1 } }
+export const H2: Story = { args: { level: 2 } }
+export const H3: Story = { args: { level: 3 } }

--- a/app/components/base/Heading/Heading.stories.tsx
+++ b/app/components/base/Heading/Heading.stories.tsx
@@ -4,13 +4,21 @@ import Heading from './Heading'
 const meta = {
   title: 'Components/Base/Heading',
   component: Heading,
-  args: { children: '見出しテキスト', level: 1 },
 } satisfies Meta<typeof Heading>
 
 export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const H1: Story = { args: { level: 1 } }
-export const H2: Story = { args: { level: 2 } }
-export const H3: Story = { args: { level: 3 } }
+// h1〜h6 を一覧で並べて見比べられる
+export const Default: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {([1, 2, 3, 4, 5, 6] as const).map((level) => (
+        <Heading key={level} level={level}>
+          Heading {level}
+        </Heading>
+      ))}
+    </div>
+  ),
+}

--- a/app/components/base/Heading/Heading.stories.tsx
+++ b/app/components/base/Heading/Heading.stories.tsx
@@ -10,8 +10,9 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-// h1〜h6 を一覧で並べて見比べられる
+// h1〜h6 を一覧で並べて見比べられる（level は必須だが render では使わない）
 export const Default: Story = {
+  args: { level: 1 },
   render: () => (
     <div className="flex flex-col gap-4">
       {([1, 2, 3, 4, 5, 6] as const).map((level) => (

--- a/app/components/base/Heading/Heading.test.tsx
+++ b/app/components/base/Heading/Heading.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Heading from './Heading'
+
+describe('Heading', () => {
+  it('level に応じた見出しタグを出力する', () => {
+    render(<Heading level={1}>タイトル</Heading>)
+
+    const heading = screen.getByRole('heading', { level: 1, name: 'タイトル' })
+    expect(heading.tagName).toBe('H1')
+  })
+
+  it('デフォルトは h2', () => {
+    render(<Heading>見出し</Heading>)
+
+    expect(screen.getByRole('heading', { name: '見出し' }).tagName).toBe('H2')
+  })
+})

--- a/app/components/base/Heading/Heading.test.tsx
+++ b/app/components/base/Heading/Heading.test.tsx
@@ -10,9 +10,9 @@ describe('Heading', () => {
     expect(heading.tagName).toBe('H1')
   })
 
-  it('デフォルトは h2', () => {
-    render(<Heading>見出し</Heading>)
+  it('level=3 は h3 を出力する', () => {
+    render(<Heading level={3}>小見出し</Heading>)
 
-    expect(screen.getByRole('heading', { name: '見出し' }).tagName).toBe('H2')
+    expect(screen.getByRole('heading', { name: '小見出し' }).tagName).toBe('H3')
   })
 })

--- a/app/components/base/Heading/Heading.tsx
+++ b/app/components/base/Heading/Heading.tsx
@@ -4,8 +4,8 @@ import { cn } from '~/lib/utils'
 type Level = 1 | 2 | 3 | 4 | 5 | 6
 
 type HeadingProps = ComponentProps<'h2'> & {
-  /** 見出しレベル（1〜6）→ h1〜h6 を出力する。ページの主見出しは 1。 */
-  level?: Level
+  /** 見出しレベル（1〜6）→ h1〜h6 を出力する（必須・明示指定）。ページの主見出しは 1。 */
+  level: Level
 }
 
 // レベルごとの既定サイズ（className で上書き可）
@@ -22,11 +22,7 @@ const sizeByLevel: Record<Level, string> = {
  * 見出し（h1〜h6）。色はテーマトークン（`text-foreground`）でダーク対応。
  * サイズは level の既定値を使い、`className` で上書きできる。
  */
-export default function Heading({
-  level = 2,
-  className,
-  ...props
-}: HeadingProps) {
+export default function Heading({ level, className, ...props }: HeadingProps) {
   const Tag = `h${level}` as ElementType
   return (
     <Tag

--- a/app/components/base/Heading/Heading.tsx
+++ b/app/components/base/Heading/Heading.tsx
@@ -1,0 +1,37 @@
+import type { ComponentProps, ElementType } from 'react'
+import { cn } from '~/lib/utils'
+
+type Level = 1 | 2 | 3 | 4 | 5 | 6
+
+type HeadingProps = ComponentProps<'h2'> & {
+  /** 見出しレベル（1〜6）→ h1〜h6 を出力する。ページの主見出しは 1。 */
+  level?: Level
+}
+
+// レベルごとの既定サイズ（className で上書き可）
+const sizeByLevel: Record<Level, string> = {
+  1: 'text-3xl',
+  2: 'text-2xl',
+  3: 'text-xl',
+  4: 'text-lg',
+  5: 'text-base',
+  6: 'text-sm',
+}
+
+/**
+ * 見出し（h1〜h6）。色はテーマトークン（`text-foreground`）でダーク対応。
+ * サイズは level の既定値を使い、`className` で上書きできる。
+ */
+export default function Heading({
+  level = 2,
+  className,
+  ...props
+}: HeadingProps) {
+  const Tag = `h${level}` as ElementType
+  return (
+    <Tag
+      className={cn('font-bold text-foreground', sizeByLevel[level], className)}
+      {...props}
+    />
+  )
+}

--- a/app/components/base/Heading/index.ts
+++ b/app/components/base/Heading/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Heading'

--- a/app/features/about/pages/AboutPage.tsx
+++ b/app/features/about/pages/AboutPage.tsx
@@ -1,9 +1,10 @@
 import { Link } from 'react-router'
+import Heading from '~/components/base/Heading'
 
 export default function AboutPage() {
   return (
     <div className="p-8">
-      <h1 className="text-3xl font-bold text-slate-800">About</h1>
+      <Heading level={1}>About</Heading>
       <Link to="/" className="mt-4 inline-block text-blue-600 underline">
         Home へ
       </Link>

--- a/app/features/blog/pages/BlogPage.tsx
+++ b/app/features/blog/pages/BlogPage.tsx
@@ -1,7 +1,9 @@
+import Heading from '~/components/base/Heading'
+
 export default function BlogPage() {
   return (
     <div className="p-8">
-      <h1 className="text-3xl font-bold text-slate-800">Blog</h1>
+      <Heading level={1}>Blog</Heading>
     </div>
   )
 }

--- a/app/features/home/pages/HomePage.tsx
+++ b/app/features/home/pages/HomePage.tsx
@@ -1,10 +1,11 @@
 import { Link } from 'react-router'
 import Button from '~/components/base/Button'
+import Heading from '~/components/base/Heading'
 
 export default function HomePage() {
   return (
     <div className="p-8">
-      <h1 className="text-3xl font-bold text-slate-800">Home</h1>
+      <Heading level={1}>Home</Heading>
       <Link to="/about" className="mt-4 inline-block text-blue-600 underline">
         About へ
       </Link>

--- a/app/features/tools/pages/ToolsPage.tsx
+++ b/app/features/tools/pages/ToolsPage.tsx
@@ -1,7 +1,9 @@
+import Heading from '~/components/base/Heading'
+
 export default function ToolsPage() {
   return (
     <div className="p-8">
-      <h1 className="text-3xl font-bold text-slate-800">Tools</h1>
+      <Heading level={1}>Tools</Heading>
     </div>
   )
 }

--- a/app/features/works/pages/WorksPage.tsx
+++ b/app/features/works/pages/WorksPage.tsx
@@ -1,7 +1,9 @@
+import Heading from '~/components/base/Heading'
+
 export default function WorksPage() {
   return (
     <div className="p-8">
-      <h1 className="text-3xl font-bold text-slate-800">Works</h1>
+      <Heading level={1}>Works</Heading>
     </div>
   )
 }

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -124,7 +124,8 @@ my-portfolio/
 │   ├── components/          # アプリ共通のコンポーネント
 │   │   ├── base/           #   汎用プリミティブ（コンポーネントごとにディレクトリ）
 │   │   │   ├── Button/     #     Button.tsx / .test.tsx / .stories.tsx / index.ts
-│   │   │   └── Avatar/     #     ui/avatar のラッパー（src/alt/fallback/className）
+│   │   │   ├── Avatar/     #     ui/avatar のラッパー（src/alt/fallback/className）
+│   │   │   └── Heading/    #     見出し h1〜h6（level prop・text-foreground でダーク対応）
 │   │   ├── layout/         #   全ページ横断のレイアウトのガワ
 │   │   │   ├── Header/     #     サイト共通ヘッダー（layout ルートで表示）
 │   │   │   ├── MobileNav/  #     モバイル用ハンバーガーメニュー（Sheet）


### PR DESCRIPTION
## 概要
見出し用の **Heading コンポーネント**（`app/components/base/Heading/`）を追加し、各ページの見出しを置き換える。固定色をやめてダークモードに追従させる。

## Heading（`base/Heading/`）
- `level`（1〜6）→ `h1`〜`h6` を出力（ページ主見出しは `level={1}`）
- 色は **`text-foreground`（テーマトークン）** → ライト/ダーク両対応
- サイズは level ごとの既定値（h1=text-3xl 等）＋ `className` で上書き可
- test / story / バレル付き（story title `Components/Base/Heading`）

## 適用
- Home / About / Tools / Blog / Works の `<h1 class="... text-slate-800">` を `<Heading level={1}>` に置換
- → 見出しの**固定色 `text-slate-800` を一掃**（バックログ「固定色→テーマトークン」の見出し分を消化）

## 確認
- `biome ci` / `typecheck` / `test`（15 passed）/ `build`（見出しが `h1 + text-foreground` で出力）/ `build-storybook` すべて成功
- `app/` 内に `text-slate-800` が残っていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)