### PR TITLE
Home 画面をヒーローレイアウトに実装

### DIFF
--- a/app/features/home/pages/HomePage.test.tsx
+++ b/app/features/home/pages/HomePage.test.tsx
@@ -1,21 +1,20 @@
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router'
 import { describe, expect, it } from 'vitest'
 import HomePage from './HomePage'
 
 describe('HomePage', () => {
-  it('見出しと About へのリンクを表示する', () => {
-    render(
-      <MemoryRouter>
-        <HomePage />
-      </MemoryRouter>,
-    )
+  it('ウェルカム見出しと自己紹介文を表示する', () => {
+    render(<HomePage />)
 
-    expect(screen.getByRole('heading', { name: 'Home' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'About へ' })).toHaveAttribute(
-      'href',
-      '/about',
-    )
-    expect(screen.getByRole('button', { name: 'ボタン' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: "Welcome to Ryo's Portfolio!",
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('はじめまして。')).toBeInTheDocument()
+    expect(
+      screen.getByText('当サイトはエンジニアとしてのポートフォリオです。'),
+    ).toBeInTheDocument()
   })
 })

--- a/app/features/home/pages/HomePage.tsx
+++ b/app/features/home/pages/HomePage.tsx
@@ -1,22 +1,42 @@
-import { Link } from 'react-router'
-import Button from '~/components/base/Button'
+import Avatar from '~/components/base/Avatar'
 import Heading from '~/components/base/Heading'
 
 export default function HomePage() {
   return (
-    <div className="p-8">
-      <Heading level={1}>Home</Heading>
-      <Link to="/about" className="mt-4 inline-block text-blue-600 underline">
-        About へ
-      </Link>
-      <div className="mt-4">
-        <Button>ボタン</Button>
+    <div className="fade-in slide-in-from-bottom-4 flex flex-1 animate-in flex-col items-center justify-center gap-10 p-8 duration-700 md:flex-row md:gap-20">
+      <div className="flex max-w-xl flex-col gap-12">
+        <Heading
+          level={1}
+          className="text-4xl text-balance tracking-tight md:text-5xl"
+        >
+          Welcome to{' '}
+          <span className="relative inline-block">
+            Ryo's Portfolio!
+            <span
+              aria-hidden="true"
+              className="-z-10 -rotate-1 absolute inset-x-0 bottom-1 h-4 bg-foreground/15 md:h-5 dark:bg-foreground/30"
+            />
+          </span>
+        </Heading>
+        <div className="flex flex-col gap-3 text-muted-foreground leading-8">
+          <p>はじめまして。</p>
+          <p>
+            Webフロントエンドエンジニアの{' '}
+            <span className="font-bold text-2xl text-foreground leading-none">
+              Ryo
+            </span>{' '}
+            です。
+          </p>
+          <p>当サイトはエンジニアとしてのポートフォリオです。</p>
+          <p>是非ご覧下さい！</p>
+        </div>
       </div>
-
-      {/* TODO: sticky ヘッダーのスクロール確認用の仮コンテンツ。本実装時に削除する */}
-      <div className="mt-8 flex h-[150vh] items-start rounded bg-slate-100 p-4 text-slate-500">
-        スクロール確認用の仮コンテンツ（本実装時に削除）
-      </div>
+      <Avatar
+        src="/avatar.jpg"
+        alt="Ryo のアバター"
+        fallback="R"
+        className="size-48 shadow-lg md:size-64"
+      />
     </div>
   )
 }

--- a/app/routes/layout.tsx
+++ b/app/routes/layout.tsx
@@ -7,7 +7,7 @@ export default function Layout() {
   return (
     <div className="flex min-h-svh flex-col">
       <Header />
-      <main className="flex-1">
+      <main className="flex flex-1 flex-col">
         <Outlet />
       </main>
       <Footer />


### PR DESCRIPTION
## 概要
Home 画面を実装。**中央に「左：ウェルカム見出し＋自己紹介文 / 右：大きめの丸アバター」**を配置し、**スマホサイズ（md 未満）では文字→画像の上下積み**にする。

## レイアウト・見た目
- 見出し `Welcome to Ryo's Portfolio!`（Heading level=1・`text-4xl md:text-5xl`・`tracking-tight`・`text-balance`）
  - 「Ryo's Portfolio!」に**モノクロのマーカー風アクセント**（`bg-foreground/15`・軽い傾き・ダークは `/30` で視認性確保）
- 自己紹介文は `text-muted-foreground`、名前「Ryo」のみ `text-foreground` の大きめ太字で強調
  - 全行 `leading-8` で行高さを統一（強調文字の行は `leading-none` で行ボックスの膨らみを防止）
- アバター `size-48 md:size-64` + `shadow-lg`
- 表示時に下からフェードイン（tw-animate-css）
- 縦中央寄せのため layout の `main` を flex コンテナ化

## 削除
- sticky 確認用の仮コンテンツ（h-[150vh] ダミー）※バックログ予定どおり
- デモボタン・About リンク（テストも新レイアウトに更新）

## 確認
- `biome ci` / `typecheck` / `test`（16 passed）/ `build`（prerender・Home 描画確認）すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)