### PR TITLE
和文フォント Noto Sans JP を追加

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -2,12 +2,13 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/geist";
+@import "@fontsource-variable/noto-sans-jp";
 
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
   --font-heading: var(--font-sans);
-  --font-sans: "Geist Variable", sans-serif;
+  --font-sans: "Geist Variable", "Noto Sans JP Variable", sans-serif;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -37,6 +37,7 @@
 
 - **Tailwind CSS** `^4.3.0` — ユーティリティファースト CSS
 - **@tailwindcss/vite** `^4.3.0` — Vite プラグイン（`vite.config.ts` で読み込み、`app/app.css` で `@import "tailwindcss"`）
+- **フォント**：欧文 **Geist**（`@fontsource-variable/geist`）＋ 和文 **Noto Sans JP**（`@fontsource-variable/noto-sans-jp`）。`app/app.css` の `--font-sans` に両方を指定し、環境差なく表示（unicode-range 分割で必要な文字だけロード）
 
 ## UI コンポーネント（shadcn/ui）
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource-variable/noto-sans-jp": "^5.2.10",
     "@react-router/node": "^7.17.0",
     "@react-router/serve": "^8.2.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@fontsource-variable/geist':
         specifier: ^5.2.9
         version: 5.2.9
+      '@fontsource-variable/noto-sans-jp':
+        specifier: ^5.2.10
+        version: 5.2.10
       '@react-router/node':
         specifier: ^7.17.0
         version: 7.17.0(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
@@ -722,6 +725,9 @@ packages:
 
   '@fontsource-variable/geist@5.2.9':
     resolution: {integrity: sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==}
+
+  '@fontsource-variable/noto-sans-jp@5.2.10':
+    resolution: {integrity: sha512-m0XfZ38rZtCaGAuAQL0cBPQ6fc/RguYEOqw66zvuLOV9vNRUBf9MFqyoazTu2JVCRIcnkrxbwF29UUaHHgTKdg==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -4779,6 +4785,8 @@ snapshots:
   '@floating-ui/utils@0.2.11': {}
 
   '@fontsource-variable/geist@5.2.9': {}
+
+  '@fontsource-variable/noto-sans-jp@5.2.10': {}
 
   '@hono/node-server@1.19.14(hono@4.12.29)':
     dependencies:


### PR DESCRIPTION
## 概要
これまで和文は OS 標準フォント頼み（Geist に日本語グリフが無い）で、閲覧環境により見た目が変わっていた。**Noto Sans JP** を追加し、どの環境でも同じ日本語表示にする。

## 変更点
- `@fontsource-variable/noto-sans-jp` を追加
- `app/app.css`：`@import` を追加し、`--font-sans` を **"Geist Variable", "Noto Sans JP Variable", sans-serif** に（欧文は Geist、和文は Noto Sans JP に自動フォールバック）
- TECH_STACK.md にフォント構成を追記

## 補足
- **Mac ではヒラギノと似ているため見た目の変化は小さい**。主な効果は Windows / Android での表示統一
- fontsource の variable フォントは **unicode-range 分割**されており、実際に使う文字帯域の woff2 のみダウンロードされる

## 確認
- `biome ci` / `typecheck` / `test`（16 passed）/ `build`（CSS に @font-face 反映・woff2 出力を確認）すべて成功
- DevTools の Rendered Fonts で `Noto Sans JP Variable` の適用を確認可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)